### PR TITLE
Feature/permission by group name and user email

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ Usage: <main class> [options] [command] [command options]
              'view' or 'publish'
              Default: view
               --groupIds
-             group ids
+             group names or ids
               --target
              target file
               --userIds
-             user ids
+             user emails or ids
 
     configure      Bootstrap a the client .properties file
       Usage: configure [options]
@@ -146,24 +146,28 @@ Usage: <main class> [options] [command] [command options]
               --ignoreFailure
              Do not report error when failed.
              Default: false
-              --permission
-             set permissions for folder
               --title
              title of the new folder
+              --users
+             set users permissions for folder
+              --groups
+             set groups permissions for folder
 
     publish      Refresh a Roambi document
       Usage: publish [options]
         Options:
               --folder
              remote folder destination
-              --permission
-             set permissions for new document
               --source
              remote source file
               --template
              template rbi
               --title
              title of the new document
+              --users
+             set users permissions for new document
+              --groups
+             set groups permissions for new document
 
     publish-with-file      Refresh a Roambi document based on data in a local file
       Usage: publish-with-file [options]
@@ -172,22 +176,24 @@ Usage: <main class> [options] [command] [command options]
              local source file
               --folder
              remote folder destination
-              --permission
-             set permissions for new document
               --template
              template rbi
               --title
              title of the new document
+              --users
+             set users permissions for new document
+              --groups
+             set groups permissions for new document
 
     removePermission      remove permissions to a file
       Usage: removePermission [options]
         Options:
               --groupIds
-             group ids
+             group names or ids
               --target
              target file
               --userIds
-             user ids
+             user emails or ids
 
     rmdir      Delete a folder in the Roambi Repository
       Usage: rmdir [options]
@@ -219,10 +225,12 @@ Usage: <main class> [options] [command] [command options]
              locale file you with to upload
               --folder
              remote folder destination
-              --permission
-             set permissions for new file
               --title
              title of the new file
+              --users
+             set users permissions for new file
+              --groups
+             set groups permissions for new file
 
     version      Usage: version [options]
 

--- a/roambi-script/README.md
+++ b/roambi-script/README.md
@@ -116,11 +116,11 @@ Usage: <main class> [options] [command] [command options]
              'view' or 'publish'
              Default: view
               --groupIds
-             group ids
+             group names or ids
               --target
              target file
               --userIds
-             user ids
+             user emails or ids
 
     configure      Bootstrap a the client .properties file
       Usage: configure [options]
@@ -145,24 +145,28 @@ Usage: <main class> [options] [command] [command options]
               --ignoreFailure
              Do not report error when failed.
              Default: false
-              --permission
-             set permissions for folder
               --title
              title of the new folder
+              --users
+             set users permissions for folder
+              --groups
+             set groups permissions for folder
 
     publish      Refresh a Roambi document
       Usage: publish [options]
         Options:
               --folder
              remote folder destination
-              --permission
-             set permissions for new document
               --source
              remote source file
               --template
              template rbi
               --title
              title of the new document
+              --users
+             set users permissions for new document
+              --groups
+             set groups permissions for new document
 
     publish-with-file      Refresh a Roambi document based on data in a local file
       Usage: publish-with-file [options]
@@ -171,22 +175,24 @@ Usage: <main class> [options] [command] [command options]
              local source file
               --folder
              remote folder destination
-              --permission
-             set permissions for new document
               --template
              template rbi
               --title
              title of the new document
+              --users
+             set users permissions for new document
+              --groups
+             set groups permissions for new document
 
     removePermission      remove permissions to a file
       Usage: removePermission [options]
         Options:
               --groupIds
-             group ids
+             group names or ids
               --target
              target file
               --userIds
-             user ids
+             user emails or ids
 
     rmdir      Delete a folder in the Roambi Repository
       Usage: rmdir [options]
@@ -218,10 +224,12 @@ Usage: <main class> [options] [command] [command options]
              locale file you with to upload
               --folder
              remote folder destination
-              --permission
-             set permissions for new file
               --title
              title of the new file
+              --users
+             set users permissions for new file
+              --groups
+             set groups permissions for new file
 
     version      Usage: version [options]
 

--- a/roambi-script/src/main/java/com/mellmo/roambi/cli/commands/AddPermissionCommand.java
+++ b/roambi-script/src/main/java/com/mellmo/roambi/cli/commands/AddPermissionCommand.java
@@ -4,6 +4,8 @@
  */
 package com.mellmo.roambi.cli.commands;
 
+import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,7 +16,6 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.mellmo.roambi.api.RoambiApiClient;
 import com.mellmo.roambi.api.model.RoambiFilePermission;
-import com.mellmo.roambi.cli.client.RoambiClientUtil;
 
 /**
  * Created with IntelliJ IDEA.
@@ -31,10 +32,10 @@ public class AddPermissionCommand extends CommandBase {
     @Parameter(names="--target", description="target file")
     private String remoteUid;
 
-    @Parameter(names="--groupIds", variableArity = true, description="group ids", required=false)
+    @Parameter(names="--groupIds", variableArity = true, description="group names or ids", required=false)
     private List<String> groupIds;
 
-    @Parameter(names="--userIds", variableArity = true, description = "user ids", required=false)
+    @Parameter(names="--userIds", variableArity = true, description = "user emails or ids", required=false)
     private List<String> userIds;
 
     @Parameter(names="--access", description = "'view' or 'publish'")
@@ -65,13 +66,10 @@ public class AddPermissionCommand extends CommandBase {
         logger.info("access: " + mode);
 
         client.currentUser();
-        if(groupIds.size() > 0 || userIds.size() > 0){
-            client.addPermission(
-            		client.getItemInfo(remoteUid),
-                    groupIds.size()>0?RoambiClientUtil.getGroupIds(groupIds, client):groupIds,
-                    userIds.size()>0?RoambiClientUtil.getUserIds(userIds, client):userIds,
-                    getPermission(mode));
-        } else {
+        if (isNotEmpty(userIds) || isNotEmpty(groupIds)) {
+        	client.addPermission(client.getItemInfo(remoteUid), groupIds, userIds, getPermission(mode));
+        }
+        else {
             throw new Exception("No groups or users specified.");
         }
 

--- a/roambi-script/src/main/java/com/mellmo/roambi/cli/commands/CreateFolderCommand.java
+++ b/roambi-script/src/main/java/com/mellmo/roambi/cli/commands/CreateFolderCommand.java
@@ -5,6 +5,7 @@
 package com.mellmo.roambi.cli.commands;
 
 import static com.mellmo.roambi.cli.client.RoambiClientUtil.toContentItem;
+import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 
 import java.util.List;
 
@@ -16,6 +17,7 @@ import com.beust.jcommander.Parameters;
 import com.mellmo.roambi.api.RoambiApiClient;
 import com.mellmo.roambi.api.exceptions.ApiException;
 import com.mellmo.roambi.api.model.ContentItem;
+import com.mellmo.roambi.api.model.RoambiFilePermission;
 import com.mellmo.roambi.cli.client.RoambiClientUtil;
 
 /**
@@ -37,8 +39,13 @@ public class CreateFolderCommand extends CommandBase {
     @Parameter(names="--title", description="title of the new folder")
     private String title;
 
-    @Parameter(names="--permission", description="set permissions for folder", variableArity = true, required=false)
+    @Deprecated @Parameter(names="--permission", description="(Deprecated) set permissions for folder", variableArity = true, required=false)
     private List<String> permissionIds;
+    
+    @Parameter(names="--users", description="set users permissions for folder", variableArity=true, required=false)
+	protected List<String> users;
+	@Parameter(names="--groups", description="set groups permissions for folder", variableArity=true, required=false)
+	protected List<String> groups;
 
     @Parameter(names="--ignoreFailure", description = "Do not report error when failed.", required = false)
     private boolean ignoreFailure;
@@ -55,15 +62,23 @@ public class CreateFolderCommand extends CommandBase {
         logger.info("title: " + title);
         if(permissionIds !=null) {
             logger.info("permission:" + permissionIds.toString());
+            logger.warn("permission parameter is deprecated, use users and groups parameters instead.");
         }
+		if (users != null)	logger.info("users:" + users.toString());
+		if (groups != null)	logger.info("groups:" + groups.toString());
 
         client.currentUser();
 
         try {
         	final ContentItem newFolder = client.createFolder(toContentItem(parentFolder), title);
-            if(permissionIds != null && newFolder != null) {
-                RoambiClientUtil.addPermission(newFolder, permissionIds, client);
-            }
+        	if (newFolder != null) {
+				if (isNotEmpty(users) || isNotEmpty(groups)) {
+					client.addPermission(newFolder, groups, users, RoambiFilePermission.WRITE);
+				}
+				else if (permissionIds != null) {
+					RoambiClientUtil.addPermission(newFolder, permissionIds, client);
+				}
+			}
         } catch(ApiException e) {
             if (ignoreFailure) {
                 logger.warn(e.getLocalizedMessage());

--- a/roambi-script/src/main/java/com/mellmo/roambi/cli/commands/RemovePermissionCommand.java
+++ b/roambi-script/src/main/java/com/mellmo/roambi/cli/commands/RemovePermissionCommand.java
@@ -4,6 +4,8 @@
  */
 package com.mellmo.roambi.cli.commands;
 
+import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,7 +15,6 @@ import org.slf4j.LoggerFactory;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.mellmo.roambi.api.RoambiApiClient;
-import com.mellmo.roambi.cli.client.RoambiClientUtil;
 
 /**
  * Created with IntelliJ IDEA.
@@ -31,10 +32,10 @@ public class RemovePermissionCommand extends CommandBase {
     @Parameter(names="--target", description="target file")
     private String remoteUid;
 
-    @Parameter(names="--groupIds", variableArity = true, description="group ids", required=false)
+    @Parameter(names="--groupIds", variableArity = true, description="group names or ids", required=false)
     private List<String> groupIds;
 
-    @Parameter(names="--userIds", variableArity = true, description = "user ids", required=false)
+    @Parameter(names="--userIds", variableArity = true, description = "user emails or ids", required=false)
     private List<String> userIds;
 
 
@@ -58,12 +59,10 @@ public class RemovePermissionCommand extends CommandBase {
         logger.info("groups: " + groupIds.toString());
 
         client.currentUser();
-        if(groupIds.size() > 0 || userIds.size() > 0){
-            client.removePermission(
-            		client.getItemInfo(remoteUid),
-                    groupIds.size()>0?RoambiClientUtil.getGroupIds(groupIds, client):groupIds,
-                    userIds.size()>0?RoambiClientUtil.getUserIds(userIds, client):userIds);
-        } else {
+        if (isNotEmpty(userIds) || isNotEmpty(groupIds)) {
+        	client.removePermission(client.getItemInfo(remoteUid), groupIds, userIds);
+        }
+        else {
             throw new Exception("No groups or users specified.");
         }
 


### PR DESCRIPTION
public api server now accepts group names (case sensitive) and user emails (case insensitive) in additional to their uids when the clients want to sent permissions on files or folders